### PR TITLE
Enable snippets in Javascript React (JSX) files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
 			{
 				"language": "javascript",
 				"path": "./snippets/snippets.json"
+			},
+      {
+				"language": "javascriptreact",
+				"path": "./snippets/snippets.json"
 			}
 		]
 	}


### PR DESCRIPTION
Currently the snippets only work if the language mode is set to Javascript. This enables them in Javascript React files as well.
